### PR TITLE
CORS support enabled

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,6 +2,7 @@ astroid==2.3.3
 Babel==2.7.0
 Click==7.0
 Django==2.2.7
+django-cors-headers==3.2.0
 django-phonenumber-field==3.0.1
 djangorestframework==3.10.3
 Flask==1.1.1

--- a/src/usamo/settings.py
+++ b/src/usamo/settings.py
@@ -35,14 +35,16 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'cv.apps.CvConfig',
-    'rest_framework',
     'phonenumber_field',
-    'account.apps.AccountConfig',
+    'rest_framework',
     'rest_framework.authtoken',
+    'corsheaders',
+    'cv.apps.CvConfig',
+    'account.apps.AccountConfig',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -115,6 +117,19 @@ AUTH_PASSWORD_VALIDATORS = [
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.2/topics/i18n/
+
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_HEADERS = (
+    'accept',
+    'accept-encoding',
+    'authorization',
+    'content-type',
+    'dnt',
+    'origin',
+    'user-agent',
+    'x-csrftoken',
+    'x-requested-with',
+)
 
 LANGUAGE_CODE = 'en-us'
 


### PR DESCRIPTION
Do wysyłania requestów z innych aplikacji musimy ustawić cors, na razie ustawione jest na otwarte dla wszystkich, gdy ustalimy adresy np. frontu powinniśmy ustawić whitelistę