### PR TITLE
Offers models fix

### DIFF
--- a/src/blog/migrations/0001_initial.py
+++ b/src/blog/migrations/0001_initial.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('account', '0002_auto_20200314_1754'),
+        ('account', '0002_auto_20200402_1948'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 

--- a/src/job/fixtures/test_joboffers.json
+++ b/src/job/fixtures/test_joboffers.json
@@ -1,8 +1,35 @@
 [
   {
+    "model": "job.joboffercategory",
+    "pk": "IT",
+    "fields": {}
+  },
+  {
+    "model": "job.joboffercategory",
+    "pk": "PR",
+    "fields": {}
+  },
+  {
+    "model": "job.joboffertype",
+    "pk": "Praca",
+    "fields": {}
+  },
+  {
+    "model": "job.joboffertype",
+    "pk": "Praktyki",
+    "fields": {}
+  },
+  {
+    "model": "job.joboffertype",
+    "pk": "Sta\u017c",
+    "fields": {}
+  },
+  {
     "model": "job.joboffer",
     "pk": "47991e86-4b42-4507-b154-1548bf8a3bd3",
     "fields": {
+      "category": "IT",
+      "offer_type": "Sta\u017c",
       "offer_name": "offer1",
       "company_name": "company1",
       "company_address": "adress1",
@@ -18,6 +45,8 @@
     "model": "job.joboffer",
     "pk": "fbca7511-3879-47b6-ab08-8d39ccc2b6f3",
     "fields": {
+      "category": "PR",
+      "offer_type": "Praca",
       "offer_name": "offer2",
       "company_name": "company2",
       "company_address": "adress2",

--- a/src/job/models.py
+++ b/src/job/models.py
@@ -2,14 +2,25 @@ import uuid
 
 from django.contrib.auth.models import User
 from django.db import models
+from django.db.models import SET_NULL
 
 from .enums import Voivodeships
 from account.models import DefaultAccount, EmployerAccount
 
 
+class JobOfferCategory(models.Model):
+    name = models.CharField(max_length=30, primary_key=True)
+
+
+class JobOfferType(models.Model):
+    name = models.CharField(max_length=30, primary_key=True)
+
+
 class JobOffer(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     offer_name = models.CharField(max_length=50)
+    category = models.ForeignKey(JobOfferCategory, on_delete=SET_NULL, null=True, db_column='category')
+    offer_type = models.ForeignKey(JobOfferType, on_delete=SET_NULL, null=True, db_column='offer_type')
     company_name = models.CharField(max_length=70)
     company_address = models.CharField(max_length=200)
     voivodeship = models.CharField(max_length=30, choices=Voivodeships.choices)
@@ -26,12 +37,16 @@ class JobOffer(models.Model):
 class JobOfferEdit:
     def __init__(self,
                  offer_name=None,
+                 category=None,
+                 offer_type=None,
                  company_name=None,
                  company_address=None,
                  voivodeship=None,
                  expiration_date=None,
                  description=None):
         self.offer_name = offer_name
+        self.category = category
+        self.offer_type = offer_type
         self.company_name = company_name
         self.company_address = company_address
         self.voivodeship = voivodeship
@@ -45,13 +60,19 @@ class JobOfferEdit:
 class JobOfferFilters:
     def __init__(self,
                  voivodeship=None,
-                 min_expiration_date=None):
+                 min_expiration_date=None,
+                 categories=None,
+                 types=None):
         self.voivodeship = voivodeship
         self.min_expiration_date = min_expiration_date
+        self.categories = categories
+        self.types = types
 
     def get_filters(self):
         filters = dict(
             voivodeship=self.voivodeship,
-            expiration_date__gte=self.min_expiration_date
+            expiration_date__gte=self.min_expiration_date,
+            category__in=self.categories,
+            offer_type__in=self.types
         )
         return {k: v for k, v in filters.items() if v is not None}

--- a/src/job/serializers.py
+++ b/src/job/serializers.py
@@ -8,6 +8,8 @@ from .models import *
 
 class JobOfferSerializer(serializers.ModelSerializer):
     voivodeship = serializers.ChoiceField(choices=Voivodeships.choices)
+    category = serializers.CharField(source='category.name')
+    type = serializers.CharField(source='offer_type.name')
 
     def validate_expiration_date(self, value):
         today = date.today()
@@ -17,12 +19,19 @@ class JobOfferSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = JobOffer
-        fields = ['id', 'offer_name', 'company_name', 'company_address', 'voivodeship', 'expiration_date',
+        fields = ['id', 'offer_name', 'category', 'type', 'company_name', 'company_address', 'voivodeship', 'expiration_date',
                   'description']
+
+    def create(self, validated_data):
+        validated_data['category'] = JobOfferCategory.objects.get(**validated_data['category'])
+        validated_data['offer_type'] = JobOfferType.objects.get(**validated_data['offer_type'])
+        return JobOffer(**validated_data)
 
 
 class JobOfferEditSerializer(serializers.Serializer):
     offer_name = serializers.CharField(max_length=50, required=False)
+    category = serializers.CharField(max_length=30, required=False)
+    type = serializers.CharField(max_length=30, required=False)
     company_name = serializers.CharField(max_length=70, required=False)
     company_address = serializers.CharField(max_length=200, required=False)
     voivodeship = serializers.CharField(max_length=30, required=False)
@@ -30,9 +39,17 @@ class JobOfferEditSerializer(serializers.Serializer):
     description = serializers.CharField(max_length=1000, required=False)
 
     def create(self, validated_data):
+        if 'category' in validated_data:
+            validated_data['category'] = JobOfferCategory.objects.get(name=validated_data.pop('category'))
+        if 'type' in validated_data:
+            validated_data['offer_type'] = JobOfferType.objects.get(name=validated_data.pop('type'))
         return JobOfferEdit(**validated_data)
 
     def update(self, instance, validated_data):
+        if 'category' in validated_data:
+            instance.category = JobOfferCategory.objects.get(name=validated_data('category'))
+        if 'type' in validated_data:
+            instance.offer_name = JobOfferType.objects.get(name=validated_data('type'))
         instance.offer_name = validated_data.get('offer_name', instance.offer_name)
         instance.company_name = validated_data.get('company_name', instance.company_name)
         instance.company_address = validated_data.get('company_address', instance.company_address)
@@ -45,6 +62,8 @@ class JobOfferEditSerializer(serializers.Serializer):
 class JobOfferFiltersSerializer(serializers.Serializer):
     voivodeship = serializers.CharField(max_length=30, required=False)
     min_expiration_date = serializers.DateField(required=False)
+    categories = serializers.ListField(child=serializers.CharField(max_length=30), required=False)
+    types = serializers.ListField(child=serializers.CharField(max_length=30), required=False)
 
     def create(self, validated_data):
         return JobOfferFilters(**validated_data)
@@ -52,6 +71,8 @@ class JobOfferFiltersSerializer(serializers.Serializer):
     def update(self, instance, validated_data):
         instance.voivodeship = validated_data.get('voivodeship', instance.voivodeship)
         instance.min_expiration_date = validated_data.get('min_expiration_date', instance.min_expiration_date)
+        instance.categories = validated_data.get('categories', instance.categories)
+        instance.types = validated_data.get('types', instance.types)
         return instance
 
 

--- a/src/job/views.py
+++ b/src/job/views.py
@@ -64,6 +64,8 @@ def sample_offer_response():
         properties={
             'id': Schema(type='string', default="uuid4"),
             'offer_name': Schema(type='string', default="offer name"),
+            'category': Schema(type='string', default="offer category"),
+            'type': Schema(type='string', default="offer type"),
             'company_name': Schema(type='string', default="company name"),
             'company_address': Schema(type='string', default="company address"),
             'voivodeship': Schema(type='string', default="mazowieckie"),

--- a/src/job/views.py
+++ b/src/job/views.py
@@ -219,7 +219,7 @@ class JobOfferListView(generics.ListAPIView):
         return JobOffer.objects.filter(removed=False, **valid_filters)
 
     def get(self, request):
-        self.filter_serializer = JobOfferFiltersSerializer(data=self.request.data)
+        self.filter_serializer = JobOfferFiltersSerializer(data=self.request.query_params)
         if self.filter_serializer.is_valid():
             return super().get(request)
         else:


### PR DESCRIPTION
Dodane 2 nowe pola do modelu JobOffer: 
- category - branża, np. "IT", "PR". W ramach potrzeby do dodania kolejne przez stronę admina
- offer_type - Typ, np. "Staż", "Praktyki", "Praca". W ramach potrzeby do dodania kolejne przez stronę admina

Do nich dodane 2 filtry
Można filtrować po kilku kategoriach lub typach przez przekazanie kilku parametrów o tym samym kluczu, np.:
/job/job-offers/?categories=IT&categories=PR&types=Staż