### PR TITLE
cv template now escapes all user input data

### DIFF
--- a/src/cv/templates/template2.tpl
+++ b/src/cv/templates/template2.tpl
@@ -114,11 +114,11 @@
                 {% if basic_info.picture %}<img class="picture" src="{{"../../usamo" + basic_info.picture.url}}"/>{% endif %}
             </div>
             <div id="info">
-                <h1 id="name" class="resize">{{basic_info.first_name}} {{basic_info.last_name}}</h1>
+                <h1 id="name" class="resize">{{basic_info.first_name | escape}} {{basic_info.last_name | escape}}</h1>
                 <div id="contact">
-                    <p><b>Data urodzenia: </b></br>ur. {{basic_info.date_of_birth}}</p>
-                    <p><b>Telefon: </b></br>{{basic_info.phone_number}}</p>
-                    <p><b>E-mail: </b></br>{{basic_info.email}}</p>
+                    <p><b>Data urodzenia: </b></br>ur. {{basic_info.date_of_birth | escape}}</p>
+                    <p><b>Telefon: </b></br>{{basic_info.phone_number | escape}}</p>
+                    <p><b>E-mail: </b></br>{{basic_info.email | escape}}</p>
                 </div>
             </div>
         </header>
@@ -127,9 +127,9 @@
             <h2>Wykształcenie</h2>
             {% for item in schools %}
             <div class="item">
-                <h4>{{item.year_start}} - {% if item.year_end %}{{item.year_end}}{% else %}...{% endif %}</h4>
-                <h3>{{item.name}}</h3>
-                <p>{{item.additional_info}}</p>
+                <h4>{{item.year_start | escape}} - {% if item.year_end %}{{item.year_end | escape}}{% else %}...{% endif %}</h4>
+                <h3>{{item.name | escape}}</h3>
+                <p>{{item.additional_info | escape}}</p>
             </div>
             {% endfor %}
         </div>
@@ -138,9 +138,9 @@
             <h2>Doświadczenie</h2>
             {% for item in experiences %}
             <div class="item">
-                <h4>{{item.year_start}} - {% if item.year_end %}{{item.year_end}}{% else %}...{% endif %}</h4>
-                <h3>{{item.title}}</h3>
-                <p>{{item.description}}</p>
+                <h4>{{item.year_start | escape}} - {% if item.year_end %}{{item.year_end | escape}}{% else %}...{% endif %}</h4>
+                <h3>{{item.title | escape}}</h3>
+                <p>{{item.description | escape}}</p>
             </div>
             {% endfor %}
         </div> {% endif %}
@@ -149,7 +149,7 @@
             <h2>Umiejętności</h2>
             <p class="item">
                 {% for item in skills %}
-                {{item.description}},
+                {{item.description | escape}},
                 {% endfor %}
             </p>
         </div>
@@ -158,7 +158,7 @@
             <h2>Języki</h2>
             <p class="item">
                 {% for item in languages %}
-                {{item.name}} - {{item.level}},
+                {{item.name | escape}} - {{item.level | escape}},
                 {% endfor %}
             </p>
         </div>

--- a/src/cv/urls.py
+++ b/src/cv/urls.py
@@ -19,4 +19,5 @@ urlpatterns = [
     path('admin/verification/<uuid:cv_id>/', views.AdminCVVerificationView.as_view(), name='cv_verification'),
     path('status/<uuid:cv_id>/', views.CVStatus.as_view(), name='cv_status'),
     path('name/<uuid:cv_id>/', views.UserCVNameView.as_view(), name='cv_name'),
+    path('generator/can-post', views.UserCVAvailabilityView.as_view(), name='cv_generator_can_post'),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/src/cv/views.py
+++ b/src/cv/views.py
@@ -500,6 +500,14 @@ class UserCVNameView(views.APIView):
 class UserCVAvailabilityView(views.APIView):
     permission_classes = [IsStandardUser]
 
+    @swagger_auto_schema(
+        operation_description="Informuje, czy użytkownik może postować dalsze CV (tzn. czy ma ich mniej niż 5)",
+
+        responses={
+            200: '"can_post_cv" : True/False',
+            403: 'User has no permission to perform this action.'
+        }
+    )
     def get(self, request):
         def_account = DefaultAccount.objects.get(user=request.user)
         users_cvs = CV.objects.filter(cv_user=def_account)

--- a/src/cv/views.py
+++ b/src/cv/views.py
@@ -15,7 +15,6 @@ from .serializers import *
 from .permissions import *
 from job.views import sample_message_response
 import base64
-from usamo.settings.settings import BASE_DIR
 
 class CreateCVView(views.APIView):
 
@@ -496,6 +495,19 @@ class UserCVNameView(views.APIView):
             return Response(f'CV name changed to: {request.data["name"]}', status=status.HTTP_200_OK)
         except KeyError:
             return Response('New name was not specified', status=status.HTTP_400_BAD_REQUEST)
+
+
+class UserCVAvailabilityView(views.APIView):
+    permission_classes = [IsStandardUser]
+
+    def get(self, request):
+        def_account = DefaultAccount.objects.get(user=request.user)
+        users_cvs = CV.objects.filter(cv_user=def_account)
+        if users_cvs.count() < 5:
+            response_val = True
+        else:
+            response_val = False
+        return Response({"can_post_cv" : response_val}, status=status.HTTP_200_OK)
 
 
 


### PR DESCRIPTION
Jak w commicie, templatka template2.tpl poprawiona, żeby nie wywoływała żadnych tagów html-owych

EDIT: przemyciłem jeszcze endpoint do sprawdzania czy użytkownik może postować nowe CV (tzn. czy ma ich mniej niż 5), bo Damian akurat poprosił