### PR TITLE
Poprawa walidacji hasła.

### DIFF
--- a/src/account/models.py
+++ b/src/account/models.py
@@ -1,5 +1,4 @@
 import uuid
-
 from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
 from django.contrib.auth.models import PermissionsMixin

--- a/src/usamo/settings/settings.py
+++ b/src/usamo/settings/settings.py
@@ -129,17 +129,18 @@ def _get_pdfkit_config():
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-    },
-    {
         'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
     },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
+   
     {
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
+    }
+    # {
+    #     'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    # },
+    # {
+    #     'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    # }
 ]
 
 # Internationalization


### PR DESCRIPTION
Hasło nie było w ogóle walidowane podczas rejestracji -- zauważyłem ten problem, gdy testowałem reset hasła. Tam walidatory działały.

Usunąłem dwa z domyślnych czterech systemów walidacji (zbyt popularne hasło i walidacja wobec reszty atrybutów, bo na razie mamy w fixtures np. standard1, standard1), a pozostałych użyłem w serializerze. 