### PR TITLE
Poprawione importy, FRONT_URL w .env

### DIFF
--- a/src/account/filters.py
+++ b/src/account/filters.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import Group
 from django_filters import rest_framework as filters
 from drf_yasg.inspectors import CoreAPICompatInspector, NotHandled
-from usamo.settings.settings import PASS_RESET_URL
 from .models import *
 from .account_type import *
 from .account_status import *

--- a/src/account/models.py
+++ b/src/account/models.py
@@ -1,14 +1,11 @@
 import uuid
-
-from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
-from django.contrib.auth.models import PermissionsMixin
+from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
 from phonenumber_field.modelfields import PhoneNumberField
 from rest_framework.authtoken.models import Token
-
 from .account_status import AccountStatus, ACCOUNT_STATUS_CHOICES
 from .account_type import *
 from .utils import create_profile_picture_file_path

--- a/src/account/signals.py
+++ b/src/account/signals.py
@@ -1,11 +1,9 @@
 from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 from django_rest_passwordreset.signals import reset_password_token_created
-
 from django.conf import settings
 from .utils import send_mail_via_sendgrid
 from sendgrid.helpers.mail import Mail, PlainTextContent
-from usamo.settings.settings import PASS_RESET_URL
 from django.utils import timezone
 from django.contrib.auth.signals import user_logged_in
 from .models import Account
@@ -14,7 +12,7 @@ from .models import Account
 @receiver(reset_password_token_created)
 def password_reset_token_created(sender, instance, reset_password_token, *args, **kwargs):
 
-    reset_url = PASS_RESET_URL + reset_password_token.key
+    reset_url = settings.FRONT_URL + 'newPassword/' + reset_password_token.key
     reset_token_message = f'Aby zresetować hasło, kliknij w poniższy link i postępuj zgodnie ze wskazówkami:\n{reset_url}\n\n' + \
     'Jeśli nie prosiłeś o zmianę hasła, zignoruj ten link i skontaktuj się z pomocą techniczną.\n\n Pozdrawiamyn\n Zespół usamodzielnieni.pl'
     message = Mail(

--- a/src/account/swagger.py
+++ b/src/account/swagger.py
@@ -1,6 +1,5 @@
 from drf_yasg.openapi import Schema
 from drf_yasg.utils import swagger_auto_schema
-
 from .serializers import ProfilePictureSerializer
 
 

--- a/src/account/utils.py
+++ b/src/account/utils.py
@@ -1,6 +1,5 @@
 import os
 import uuid
-
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail
 
@@ -13,9 +12,6 @@ def send_mail_via_sendgrid(message: Mail):
 
         sg = SendGridAPIClient(api_key)
         response = sg.send(message)
-        print(response.status_code)
-        print(response.body)
-        print(response.headers)
     except Exception as e:
         raise e
 

--- a/src/account/validators.py
+++ b/src/account/validators.py
@@ -1,5 +1,4 @@
 import re
-
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext
 

--- a/src/blog/filters.py
+++ b/src/blog/filters.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import Group
 from django_filters import rest_framework as filters
 from drf_yasg.inspectors import CoreAPICompatInspector, NotHandled
-from usamo.settings.settings import PASS_RESET_URL
 from .models import *
 from rest_framework.filters import OrderingFilter
 

--- a/src/blog/serializers.py
+++ b/src/blog/serializers.py
@@ -1,6 +1,5 @@
 from django.utils import timezone
 from rest_framework import serializers
-
 from .models import *
 
 

--- a/src/blog/tests.py
+++ b/src/blog/tests.py
@@ -1,9 +1,7 @@
 import uuid
-
 from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APITestCase
-
 from account.account_type import StaffGroupType
 from account.models import StaffAccount, Account
 from blog.models import *

--- a/src/blog/urls.py
+++ b/src/blog/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
-
 from . import views
+
 
 urlpatterns = [
     path('blogpost/', views.BlogPostCreateView.as_view()),

--- a/src/chat/consumers.py
+++ b/src/chat/consumers.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from .serializers import ThreadSerializer
 from notifications.signals import notify
 
+
 class ChatConsumer(AsyncJsonWebsocketConsumer):
     
     async def connect(self):

--- a/src/chat/models.py
+++ b/src/chat/models.py
@@ -1,12 +1,11 @@
 from django.db import models
-from django.conf import settings
-from django.db import models
 from django.db.models import Q
 from account.models import Account
 from account.permissions import IsStaffWithChatAccess
 from account.account_type import AccountType
 from account.account_status import AccountStatus
 import uuid
+
 
 class ThreadManager(models.Manager):
     def by_user(self, user):

--- a/src/chat/views.py
+++ b/src/chat/views.py
@@ -1,5 +1,4 @@
-from rest_framework import status
-from rest_framework import views
+from rest_framework import status, views
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response

--- a/src/cv/filters.py
+++ b/src/cv/filters.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-
 from django_filters import rest_framework as filters
 from drf_yasg.inspectors import CoreAPICompatInspector, NotHandled
 from rest_framework.filters import OrderingFilter

--- a/src/cv/serializers.py
+++ b/src/cv/serializers.py
@@ -1,11 +1,9 @@
 from phonenumber_field.validators import validate_international_phonenumber
 from rest_framework import serializers
 from django.core.files.base import ContentFile
-
 from .templates.templates import TEMPLATES_CHOICES
 from .utilities import *
 from .models import *
-
 import datetime
 
 

--- a/src/cv/tests.py
+++ b/src/cv/tests.py
@@ -1,22 +1,16 @@
-# Create your tests here.
 from unittest.mock import MagicMock
-
 from account.account_status import AccountStatus
 from account.models import Account, DefaultAccount, Address
 from django.contrib.auth.models import User
 from rest_framework import status
 from rest_framework.authtoken.models import Token
-from rest_framework.test import APITestCase
-from rest_framework.test import APIClient
+from rest_framework.test import APITestCase, APIClient
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.files import File
-from cv import models
+from cv.models import *
 from cv.cv_test_data import cv_test_data, user_data
-from cv.models import CV
-from cv.models import BasicInfo
 from cv.serializers import CVSerializer
-from rest_framework.test import APIRequestFactory
-from rest_framework.test import force_authenticate
+from rest_framework.test import APIRequestFactory, force_authenticate
 from django.db import models
 import os
 

--- a/src/cv/utilities.py
+++ b/src/cv/utilities.py
@@ -8,8 +8,17 @@ import jinja2
 import pdfkit
 import platform
 import io
-
 from .templates.templates import TEMPLATES_CHOICES
+
+
+def _get_pdfkit_config():
+    if platform.system() == 'Windows':
+        return pdfkit.configuration(wkhtmltopdf=os.environ.get('WKHTMLTOPDF_BINARY', 'C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe'))
+    else:
+        os.environ['PATH'] += os.pathsep + os.path.dirname(sys.executable)
+        WKHTMLTOPDF_CMD = subprocess.Popen(['which', os.environ.get(
+            'WKHTMLTOPDF_BINARY', 'wkhtmltopdf')], stdout=subprocess.PIPE).communicate()[0].strip()
+        return pdfkit.configuration(wkhtmltopdf=WKHTMLTOPDF_CMD)
 
 
 def create_unique_filename(prefix, ext):
@@ -63,6 +72,6 @@ def generate(data, template):
     if platform.system() != 'Windows':
         options['zoom'] = '0.78125'
     pdf = pdfkit.from_file(
-        html_path, False, configuration=settings._get_pdfkit_config(), options=options)
+        html_path, False, configuration=_get_pdfkit_config(), options=options)
     # right now it returns the pdf
     return pdf

--- a/src/cv/utilities.py
+++ b/src/cv/utilities.py
@@ -1,6 +1,6 @@
 from django.utils.crypto import get_random_string
 from rest_framework import serializers
-from usamo.settings import settings
+from django.conf import settings
 import os
 import random
 import datetime

--- a/src/cv/views.py
+++ b/src/cv/views.py
@@ -4,8 +4,7 @@ from drf_yasg import openapi
 from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework import status, generics
-from rest_framework import views
+from rest_framework import status, generics, views
 from rest_framework.generics import get_object_or_404
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
@@ -13,7 +12,6 @@ from rest_framework.response import Response
 from account.account_type import StaffGroupType
 from account.models import StaffAccount
 from account.permissions import IsStandardUser, IsCVOwner, IsStaffResponsibleForCVs, IsAGuest
-
 from .filters import CvOrderingFilter, CVListFilter, DjangoFilterDescriptionInspector
 from .models import *
 from .serializers import *

--- a/src/helpline/views.py
+++ b/src/helpline/views.py
@@ -12,8 +12,6 @@ from job.views import ErrorResponse, MessageResponse, sample_message_response, s
 from rest_framework.filters import OrderingFilter
 from blog.permissions import IsStaffBlogModerator
 
-# Create your views here.
-
 
 class PhoneContactCreateView(views.APIView):
     permission_classes = [IsStaffBlogModerator]

--- a/src/job/admin.py
+++ b/src/job/admin.py
@@ -1,7 +1,6 @@
 from django.contrib import admin
 from .models import JobOffer
 
-# Register your models here.
 
 class JobOfferAdmin(admin.ModelAdmin):
     readonly_fields = ("id", )

--- a/src/job/filters.py
+++ b/src/job/filters.py
@@ -4,7 +4,6 @@ from drf_yasg.inspectors import CoreAPICompatInspector, NotHandled
 from rest_framework.filters import OrderingFilter
 from collections import namedtuple
 from .models import JobOfferApplication
-
 import re
 
 CustomOrderingParams = namedtuple('CustomOrderingParams', ['related', 'annotate'])

--- a/src/job/jobs.py
+++ b/src/job/jobs.py
@@ -1,6 +1,5 @@
 import os
 from datetime import datetime, timedelta
-
 from apscheduler.schedulers.background import BackgroundScheduler
 from django_apscheduler.jobstores import DjangoJobStore, register_events
 

--- a/src/job/models.py
+++ b/src/job/models.py
@@ -9,8 +9,7 @@ from django.db import models
 from django.db.models import SET_NULL
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
-
-from usamo.settings import settings
+from django.conf import settings
 from .enums import Voivodeships
 from .utils import create_job_offer_image_path
 from account.models import DefaultAccount, EmployerAccount, Address

--- a/src/job/serializers.py
+++ b/src/job/serializers.py
@@ -1,7 +1,6 @@
 from datetime import date
 from account.serializers import AddressSerializer
 from rest_framework import serializers
-
 from .models import *
 
 

--- a/src/job/urls.py
+++ b/src/job/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
-
 from . import views
+
 
 urlpatterns = [
      # job offers

--- a/src/job/views.py
+++ b/src/job/views.py
@@ -1,5 +1,4 @@
 import os
-
 from notifications.signals import notify
 from rest_framework.parsers import MultiPartParser
 from account.models import EmployerAccount, DefaultAccount, Account
@@ -11,9 +10,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg.inspectors import DjangoRestResponsePagination
 from drf_yasg.openapi import Parameter, IN_PATH, IN_QUERY, Schema, IN_BODY, IN_FORM
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework import generics, serializers, filters
-from rest_framework import status
-from rest_framework import views
+from rest_framework import generics, serializers, filters, status, views
 from rest_framework.decorators import permission_classes
 from rest_framework.filters import OrderingFilter
 from rest_framework.pagination import PageNumberPagination

--- a/src/notification/jobs.py
+++ b/src/notification/jobs.py
@@ -5,6 +5,7 @@ from django_apscheduler.jobstores import DjangoJobStore, register_events, regist
 from datetime import datetime, timedelta, timezone
 from account.models import Account
 from account.utils import send_mail_via_sendgrid
+from django.conf import settings
 
 scheduler = BackgroundScheduler()
 scheduler.add_jobstore(DjangoJobStore(), "default")
@@ -24,7 +25,7 @@ def send_notification_email(pk):
             content += str(verb) + ' | ' + str(time) + '\n'
 
         message = Mail(
-            from_email='noreply@usamodzielnieni.pl',
+            from_email='no-reply@usamodzielnieni.pl',
             to_emails=email,
             subject=subject,
             plain_text_content=PlainTextContent(content))
@@ -46,13 +47,13 @@ def stop_scheduler(pk):
 def send_verification_email(pk):
     user = Account.objects.get(id=pk)
     email = user.email
-    login_url = 'http://usamodzielnieni-frontend.herokuapp.com/login'
+    login_url = settings.FRONT_URL + 'login'
     subject = f'Twoje konto w serwisie Usamodzielnieni zostało zweryfikowane!'
     content = f'Dzień dobry, {user.first_name}!\nZ przyjemnością informujemy, że Twoje konto {user.username} w ' \
               f'serwisie Usamodzielnieni zostało pomyślnie zweryfikowane. Możesz teraz zalogować się i korzystać ' \
               f'ze wszystkich dostępnych funkcji:\n{login_url}\nŻyczymy miłego dnia,\nZespół Usamodzielnionych'
     message = Mail(
-        from_email='noreply@usamodzielnieni.pl',
+        from_email='no-reply@usamodzielnieni.pl',
         to_emails=email,
         subject=subject,
         plain_text_content=PlainTextContent(content))

--- a/src/notification/urls.py
+++ b/src/notification/urls.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from . import views
 
+
 urlpatterns = [
     path('list/all', views.AllNotifications.as_view()),
     path('list/all/mark-as-read/', views.MarkAllAsRead.as_view()),

--- a/src/notification/views.py
+++ b/src/notification/views.py
@@ -4,7 +4,6 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework import views, generics, status
-
 from account.models import Account
 from job.views import MessageResponse, ErrorResponse
 from notification.serializers import *

--- a/src/steps/models.py
+++ b/src/steps/models.py
@@ -1,8 +1,6 @@
 import uuid
-
 from django.db import models
 from django.db.models import Max
-
 from account.models import DefaultAccount
 
 

--- a/src/steps/views.py
+++ b/src/steps/views.py
@@ -5,7 +5,6 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import views, generics, status
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
-
 from account.permissions import IsStaffMember
 from steps.permissions import IsStaffStepsModerator
 from job.views import ErrorResponse, MessageResponse

--- a/src/tiles/models.py
+++ b/src/tiles/models.py
@@ -1,8 +1,5 @@
 import os
-
 from django.db import models
-
-# Create your models here.
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 

--- a/src/tiles/urls.py
+++ b/src/tiles/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from . import views
 
+
 urlpatterns = [
     path('tile/', views.TileCreateView.as_view()),
     path('tile/<int:tile_id>/', views.TileView.as_view()),

--- a/src/tiles/views.py
+++ b/src/tiles/views.py
@@ -14,8 +14,6 @@ from rest_framework.filters import OrderingFilter
 from django.utils.decorators import method_decorator
 from drf_yasg import openapi
 
-# Create your views here.
-
 
 class TileCreateView(views.APIView):
     permission_classes = [IsStaffMember]

--- a/src/usamo/asgi.py
+++ b/src/usamo/asgi.py
@@ -2,6 +2,7 @@ import os
 import django
 from channels.routing import get_default_application
 
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "usamo.settings.settings")
 django.setup()
 application = get_default_application()

--- a/src/usamo/middlewares.py
+++ b/src/usamo/middlewares.py
@@ -1,7 +1,6 @@
 from django.http import JsonResponse
 from rest_framework import status
-
-from .settings.settings import MAX_UPLOAD_MB_SIZE
+from django.conf import settings
 
 
 class FilesSizeValidatorMiddleware:
@@ -10,8 +9,8 @@ class FilesSizeValidatorMiddleware:
 
     def __call__(self, request):
         for filename in request.FILES:
-            if request.FILES[filename].size > int(MAX_UPLOAD_MB_SIZE) * 1024 * 1024:
-                error_message = f'Rozmiar pliku powinien być nie większy niż {MAX_UPLOAD_MB_SIZE} MB'
+            if request.FILES[filename].size > int(settings.MAX_UPLOAD_MB_SIZE) * 1024 * 1024:
+                error_message = f'Rozmiar pliku powinien być nie większy niż {settings.MAX_UPLOAD_MB_SIZE} MB'
                 return self.__get_error_json_response(error_message)
         return self.get_response(request)
 

--- a/src/usamo/routing.py
+++ b/src/usamo/routing.py
@@ -5,6 +5,8 @@ from channels.security.websocket import AllowedHostsOriginValidator, OriginValid
 from chat.consumers import ChatConsumer, InboxConsumer
 from notification.consumers import NotificationConsumer
 from notification.token_auth import TokenAuthMiddlewareStack
+
+
 application = ProtocolTypeRouter({
     # Empty for now (http->django views is added by default)
     'websocket': AllowedHostsOriginValidator(

--- a/src/usamo/settings/settings.py
+++ b/src/usamo/settings/settings.py
@@ -139,15 +139,6 @@ CHANNEL_LAYERS = {
 
 CHANNEL_LAYERS['default']["CONFIG"]["hosts"] = [os.environ.get('REDIS_URL', 'redis://localhost:6379')]
 
-def _get_pdfkit_config():
-    if platform.system() == 'Windows':
-        return pdfkit.configuration(wkhtmltopdf=os.environ.get('WKHTMLTOPDF_BINARY', 'C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe'))
-    else:
-        os.environ['PATH'] += os.pathsep + os.path.dirname(sys.executable)
-        WKHTMLTOPDF_CMD = subprocess.Popen(['which', os.environ.get(
-            'WKHTMLTOPDF_BINARY', 'wkhtmltopdf')], stdout=subprocess.PIPE).communicate()[0].strip()
-        return pdfkit.configuration(wkhtmltopdf=WKHTMLTOPDF_CMD)
-
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
 

--- a/src/usamo/settings/settings.py
+++ b/src/usamo/settings/settings.py
@@ -26,7 +26,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv('SECRET_KEY')
-PASS_RESET_URL = os.getenv('PASS_RESET_URL')
+FRONT_URL = os.getenv('FRONT_URL')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/src/usamo/tests.py
+++ b/src/usamo/tests.py
@@ -1,9 +1,7 @@
 import shutil
 import tempfile
-
 from django.db import OperationalError, connections
 from django.test.runner import DiscoverRunner
-
 from django.conf import settings
 
 

--- a/src/usamo/urls.py
+++ b/src/usamo/urls.py
@@ -1,18 +1,3 @@
-"""usamo URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/2.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
 from django.conf.urls import url
 from django.contrib import admin
 from django.conf import settings
@@ -21,6 +6,7 @@ from django.urls import path, include
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 from rest_framework import permissions
+
 
 schema_view = get_schema_view(
    openapi.Info(

--- a/src/usamo/wsgi.py
+++ b/src/usamo/wsgi.py
@@ -1,16 +1,6 @@
-"""
-WSGI config for usamo project.
-
-It exposes the WSGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/2.2/howto/deployment/wsgi/
-"""
-
 import os
-
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'usamo.settings.settings')
 
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'usamo.settings.settings')
 application = get_wsgi_application()

--- a/src/videos/models.py
+++ b/src/videos/models.py
@@ -1,7 +1,5 @@
 from django.db import models
 
-# Create your models here.
-
 
 class VideoCategory(models.Model):
     name = models.CharField(max_length=60)

--- a/src/videos/urls.py
+++ b/src/videos/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from .views import *
 
+
 urlpatterns = [
     path('categories/', CategoriesAllView.as_view()),
     path('category/', CategoriesNewView.as_view()),

--- a/src/videos/views.py
+++ b/src/videos/views.py
@@ -1,6 +1,5 @@
 from rest_framework import generics
 from rest_framework.permissions import AllowAny, IsAuthenticated
-
 from blog.permissions import IsStaffBlogModerator
 from .serializers import *
 from .models import *


### PR DESCRIPTION
W mailach z powiadomieniami email był hardcodowany -- teraz korzystamy ze zmiennej środowiskowej tak, jak przy resecie hasła.
Usunąłem też importy typu from 'usamo.settings import settings' i w ich miejsce wstawiłem 'from django.conf import settings', który wykrywa plik z ustawieniami na podstawie zmiennej środowiskowej DJANGO_SETTINGS_MODULE.